### PR TITLE
Ensures that a file request will be a get

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  match '/paperclipdb/*dir_name/:file_name.:format' => 'paperclipdb/attachments#get_attachment'
+  get '/paperclipdb/*dir_name/:file_name.:format' => 'paperclipdb/attachments#get_attachment'
 end


### PR DESCRIPTION
Rails 4.2 accepts only a match if it comes together with a via option. In this case, `get` is a good enough call.
