### PR TITLE
Removes attr_accessible from the attachment list

### DIFF
--- a/app/models/paperclipdb/attachment.rb
+++ b/app/models/paperclipdb/attachment.rb
@@ -1,5 +1,4 @@
 module Paperclipdb
   class Attachment < ActiveRecord::Base
-    attr_accessible :base_name, :dir_name, :file_data, :content_type, :file_size
   end
 end

--- a/app/models/paperclipdb/attachment.rb
+++ b/app/models/paperclipdb/attachment.rb
@@ -1,4 +1,5 @@
 module Paperclipdb
   class Attachment < ActiveRecord::Base
+    attr_accessible :base_name, :dir_name, :file_data, :content_type, :file_size if defined? ActiveModel::MassAssignmentSecurity
   end
 end


### PR DESCRIPTION
Since Rails 4 doesn't have an attr_accessible anymore, this needs to be removed.
